### PR TITLE
Fix memory leak

### DIFF
--- a/lib/server/push.api.js
+++ b/lib/server/push.api.js
@@ -262,6 +262,8 @@ Push.Configure = function(options) {
                 });
             });
 
+            feedback.on('error', function () {});
+
             feedback.start();
         };
 


### PR DESCRIPTION
Adds a listener to the error event to fix a memory leak. I kept the current behavior of not showing errors in feedback.

If feedback has an error and there is no listener for the error event, the error is thrown which happens before the clean up code. Feedback isn't configured correctly (#331) so this happens every 5 seconds.